### PR TITLE
Fix Ohsome API url, to the non-redirecting versions

### DIFF
--- a/R/ohsome-api-requests/ohsome_api_with_R.Rmd
+++ b/R/ohsome-api-requests/ohsome_api_with_R.Rmd
@@ -28,7 +28,7 @@ There are different packages available to use for http requests with R. This tut
 ```{r}
 library(rapiclient)
 
-api <- get_api(url= "https://api.ohsome.org/v0.9-ignite/docs?group=dataAggregation")
+api <- get_api(url= "https://api.ohsome.org/v0.9/docs?group=dataAggregation")
 
 operations <- get_operations(api)
 
@@ -62,7 +62,7 @@ elementsCountGroupByBoundary <- function(x) {
   osmTypes <- "way"
   osmValues <- "yes"
 
-    r <- POST("https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary", 
+    r <- POST("https://api.ohsome.org/v0.9/elements/count/groupBy/boundary", 
             encode = "form", 
             body = list(
               bpolys = x, 
@@ -105,7 +105,7 @@ elementsCountGroupByBoundaryCSV <- function(x) {
   osmTypes <- "way"
   osmValues <- "yes"
 
-    r <- POST("https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary", 
+    r <- POST("https://api.ohsome.org/v0.9/elements/count/groupBy/boundary", 
             encode = "form", 
             body = list(
               format = "csv",

--- a/R/ohsome-api-requests/ohsome_api_with_R.md
+++ b/R/ohsome-api-requests/ohsome_api_with_R.md
@@ -93,7 +93,7 @@ response
 ```
 
     ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
-    ##   Date: 2019-03-07 11:23
+    ##   Date: 2019-03-08 09:48
     ##   Status: 200
     ##   Content-Type: application/json;charset=UTF-8
     ##   Size: 5.86 kB
@@ -129,7 +129,7 @@ response
 ```
 
     ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
-    ##   Date: 2019-03-07 11:23
+    ##   Date: 2019-03-08 09:48
     ##   Status: 200
     ##   Content-Type: application/json;charset=UTF-8
     ##   Size: 5.86 kB
@@ -185,7 +185,7 @@ response
 ```
 
     ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
-    ##   Date: 2019-03-07 11:23
+    ##   Date: 2019-03-08 09:48
     ##   Status: 200
     ##   Content-Type: text/csv;charset=UTF-8
     ##   Size: 848 B

--- a/R/ohsome-api-requests/ohsome_api_with_R.md
+++ b/R/ohsome-api-requests/ohsome_api_with_R.md
@@ -25,7 +25,7 @@ Prerequisites
 ``` r
 library(rapiclient)
 
-api <- get_api(url= "https://api.ohsome.org/v0.9-ignite/docs?group=dataAggregation")
+api <- get_api(url= "https://api.ohsome.org/v0.9/docs?group=dataAggregation")
 
 operations <- get_operations(api)
 
@@ -65,7 +65,7 @@ elementsCountGroupByBoundary <- function(x) {
   osmTypes <- "way"
   osmValues <- "yes"
 
-    r <- POST("https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary", 
+    r <- POST("https://api.ohsome.org/v0.9/elements/count/groupBy/boundary", 
             encode = "form", 
             body = list(
               bpolys = x, 
@@ -92,7 +92,7 @@ response$status_code
 response
 ```
 
-    ## Response [https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary]
+    ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
     ##   Date: 2019-03-07 11:23
     ##   Status: 200
     ##   Content-Type: application/json;charset=UTF-8
@@ -128,7 +128,7 @@ response <- elementsCountGroupByBoundary(geoJSON$text)
 response
 ```
 
-    ## Response [https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary]
+    ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
     ##   Date: 2019-03-07 11:23
     ##   Status: 200
     ##   Content-Type: application/json;charset=UTF-8
@@ -166,7 +166,7 @@ elementsCountGroupByBoundaryCSV <- function(x) {
   osmTypes <- "way"
   osmValues <- "yes"
 
-    r <- POST("https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary", 
+    r <- POST("https://api.ohsome.org/v0.9/elements/count/groupBy/boundary", 
             encode = "form", 
             body = list(
               format = "csv",
@@ -184,7 +184,7 @@ response <- elementsCountGroupByBoundaryCSV(geoJSON$text)
 response 
 ```
 
-    ## Response [https://api.ohsome.org/v0.9-ignite/elements/count/groupBy/boundary]
+    ## Response [https://api.ohsome.org/v0.9/elements/count/groupBy/boundary]
     ##   Date: 2019-03-07 11:23
     ##   Status: 200
     ##   Content-Type: text/csv;charset=UTF-8


### PR DESCRIPTION
Since the Ohsome API Urls that are not matching `/v0.9`, `/v0.9-dev` or `/v0.9-ignite-germany` are redirected, you should use the non-redirecting versions here to avoid issues with redirected requests.